### PR TITLE
Fix for title being pulled from SVGs

### DIFF
--- a/tasks/html_sitemap.js
+++ b/tasks/html_sitemap.js
@@ -78,7 +78,7 @@ module.exports = function(grunt) {
           if (options.anchor) {
             pageData.anchor = options.anchor;
           } else {
-            pageData.anchor = (!taskOpts.separator) ? $('title').text() : $('title').text().split(taskOpts.separator)[0];
+            pageData.anchor = (!taskOpts.separator) ? $('head title').text() : $('head title').text().split(taskOpts.separator)[0];
           }
 
           // The minimal amount of code a sitemap item can have


### PR DESCRIPTION
This is a fix for issue mentioned at https://github.com/Clever-Labs/grunt-html-sitemap/issues/5
